### PR TITLE
Add state to Creatable to avoid mutating the options prop

### DIFF
--- a/src/Creatable.js
+++ b/src/Creatable.js
@@ -74,6 +74,12 @@ const Creatable = createClass({
 		};
 	},
 
+	getInitialState () {
+		return {
+			newOptions: []
+		};
+	},
+
 	createNewOption () {
 		const {
 			isValidNewOption,
@@ -92,7 +98,7 @@ const Creatable = createClass({
 				if (onNewOptionClick) {
 					onNewOptionClick(option);
 				} else {
-					options.unshift(option);
+					this.setState({ newOptions: [option, ...this.state.newOptions] });
 
 					this.select.selectValue(option);
 				}
@@ -101,7 +107,7 @@ const Creatable = createClass({
 	},
 
 	filterOptions (...params) {
-		const { filterOptions, isValidNewOption, options, promptTextCreator } = this.props;
+		const { filterOptions, isValidNewOption, promptTextCreator } = this.props;
 
 		// TRICKY Check currently selected options as well.
 		// Don't display a create-prompt for a value that's selected.
@@ -213,6 +219,7 @@ const Creatable = createClass({
 		const {
 			newOptionCreator,
 			shouldKeyDownEventCreateNewOption,
+			options: propOptions = [],
 			...restProps
 		} = this.props;
 
@@ -225,8 +232,11 @@ const Creatable = createClass({
 			children = defaultChildren;
 		}
 
+		const options = [...this.state.newOptions, ...propOptions];
+
 		const props = {
 			...restProps,
+			options,
 			allowCreate: true,
 			filterOptions: this.filterOptions,
 			menuRenderer: this.menuRenderer,

--- a/test/Creatable-test.js
+++ b/test/Creatable-test.js
@@ -126,9 +126,10 @@ describe('Creatable', () => {
 		});
 		typeSearchText('foo');
 		TestUtils.Simulate.mouseDown(creatableNode.querySelector('.Select-create-option-placeholder'));
-		expect(options, 'to have length', 1);
-		expect(options[0].label, 'to equal', 'foo');
-		expect(selectedOption, 'to be', options[0]);
+		const newOptions = creatableInstance.state.newOptions;
+		expect(newOptions, 'to have length', 1);
+		expect(newOptions[0].label, 'to equal', 'foo');
+		expect(selectedOption, 'to equal', newOptions[0]);
 	});
 
 	it('should create (and auto-select) a new option when ENTER is pressed while placeholder option is selected', () => {
@@ -141,9 +142,10 @@ describe('Creatable', () => {
 		});
 		typeSearchText('foo');
 		TestUtils.Simulate.keyDown(filterInputNode, { keyCode: 13 });
-		expect(options, 'to have length', 1);
-		expect(options[0].label, 'to equal', 'foo');
-		expect(selectedOption, 'to be', options[0]);
+		const newOptions = creatableInstance.state.newOptions;
+		expect(newOptions, 'to have length', 1);
+		expect(newOptions[0].label, 'to equal', 'foo');
+		expect(selectedOption, 'to be', newOptions[0]);
 	});
 
 	it('should not create a new option if the placeholder option is not selected but should select the focused option', () => {


### PR DESCRIPTION
`Creatable` was mutating it's own `options` prop and throwing a TypeError. The best reason for this that I could find was that since React v14 they freeze props: https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html#breaking-changes.

Funny thing is I couldn't see anybody on the upstream react-select project complaining about this.

Since this is blocking me from using this component I went ahead and fixed it myself here.